### PR TITLE
Train word2vec embeddings on dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,11 @@
 *.out
 *.xml
 *.gz
+
+# python stuff
+__pycache__/
 *.pyc
+.venv
+
+# 3.4GB worth of embeddings we don't want in the source tree
+GoogleNews-vectors-negative300.bin

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@
 
 # python stuff
 __pycache__/
+.ipynb_checkpoints/
 *.pyc
 .venv
 
-# 3.4GB worth of embeddings we don't want in the source tree
-GoogleNews-vectors-negative300.bin
+# Misc. embedding files
+*.bin

--- a/data/get-embeddings.sh
+++ b/data/get-embeddings.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# The pre-trained Google News word2vec embeddings are 1.5G compressed and 3.4G
+# uncompressed, and as such will not be included in the repo. This script will
+# download and extract the embeddings for use in training.
+
+set -eE
+trap 'rm -f tmp.gz' ERR INT
+
+# from https://code.google.com/archive/p/word2vec/
+DRIVE_FILE_HASH='0B7XkCwpI5KDYNlNUTTlSS21pQmM'
+OUTPUT_FILE='GoogleNews-vectors-negative300.bin'
+wget "https://drive.usercontent.google.com/download?id=$DRIVE_FILE_HASH&export=download&confirm=yes" -O tmp.gz
+
+if command -v pv >/dev/null; then
+    zcat tmp.gz | pv >"$OUTPUT_FILE"
+else
+    zcat tmp.gz >"$OUTPUT_FILE"
+fi
+
+rm tmp.gz

--- a/src/data_normalize.py
+++ b/src/data_normalize.py
@@ -28,7 +28,7 @@ def tokenize_hyphen(tokens: list[str]) -> list[str]:
     return tokens
 
 
-def normalize_sentence(sentence: str) -> str:
+def normalize_sentence(sentence: str) -> list[str]:
     # Turn all lowercase
     # Turn contractions to canonical form
     # Tokenize sentences

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
 pandas >= 2.0.0
 scikit-learn >= 1.2.0
 nltk >= 3.8.0
+gensim >= 4.3.3
 contractions

--- a/src/word2vec.py
+++ b/src/word2vec.py
@@ -1,10 +1,12 @@
+from argparse import ArgumentParser
 from collections.abc import Iterator
+from itertools import product
 import json
 from pathlib import Path
 import sys
 
 import numpy as np
-from gensim.models import KeyedVectors, Word2Vec
+from gensim.models import Word2Vec
 
 from data_normalize import normalize_sentence
 
@@ -19,22 +21,35 @@ class Sentences:
                 data = json.loads(entry)
                 yield normalize_sentence(data['headline'])
 
-def main() -> int:
+
+def w2v_train(
+    vector_size: int = 300,
+    epochs: int = 50,
+    window: int = 5,
+    min_count: int = 1,
+    lockf: float = 0.0,
+) -> None:
     DATA_DIR = Path(__file__).parent.parent / 'data'
     GOOGLE_WORD2VEC = DATA_DIR / 'GoogleNews-vectors-negative300.bin'
     DATASET_JSON = DATA_DIR / 'Sarcasm_Headlines_Dataset.json'
-    OUTPUT_WORD2VEC = DATA_DIR / 'w2v-headline-embeddings-300d.bin'
+    OUTPUT_WORD2VEC = \
+        DATA_DIR / f'w2v-headline-embeddings-300d-e{epochs}-lockf{lockf}.bin'
+
+    print(f'-- w2v_train({vector_size=}, {window=}, {min_count=}, {epochs=}, '
+          f'{lockf=}) --')
 
     print('Initializing model...')
     headlines = Sentences(DATASET_JSON)
-    model = Word2Vec(vector_size=300, window=5, min_count=1)
+    model = Word2Vec(vector_size=vector_size, window=window, epochs=epochs,
+                     min_count=min_count)
 
     print('Building vocabulary...')
     model.build_vocab(headlines)
 
     print('Loading pretrained word2vec embeddings...')
-    model.wv.vectors_lockf = np.ones(len(model.wv))
-    model.wv.intersect_word2vec_format(GOOGLE_WORD2VEC, binary=True)
+    model.wv.vectors_lockf = np.ones((len(model.wv),), dtype=np.float32)
+    model.wv.intersect_word2vec_format(GOOGLE_WORD2VEC, binary=True,
+                                       lockf=lockf)
 
     print('Learning embeddings...')
     model.train(headlines,
@@ -44,7 +59,28 @@ def main() -> int:
     print(f'Saving embeddings to {OUTPUT_WORD2VEC}...')
     model.wv.save(str(OUTPUT_WORD2VEC))
 
+
+def main() -> int:
+    parser = ArgumentParser()
+    parser.add_argument('-m', '--min-count', type=int)
+    parser.add_argument('-w', '--window', type=int)
+    parser.add_argument('-e', '--epochs', type=int)
+    parser.add_argument('-l', '--lockf', type=float)
+    args = parser.parse_args()
+
+    # this is kinda dumb but it works!
+    kwargs = {k: v for k, v in args._get_kwargs() if v is not None}
+    if kwargs:
+        w2v_train(**kwargs)
+        return 0
+
+    # if no arguments were passed...
+    epochs = (5, 50, 100, 200)
+    lockfs = (0.0, 1.0)
+    for epoch, lockf in product(epochs, lockfs):
+        w2v_train(epochs=epoch, lockf=lockf)
     return 0
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/src/word2vec.py
+++ b/src/word2vec.py
@@ -1,0 +1,57 @@
+from collections.abc import Iterator
+import json
+from pathlib import Path
+import sys
+
+import numpy as np
+from gensim.models import KeyedVectors, Word2Vec
+
+from data_normalize import normalize_sentence
+
+
+class Sentences:
+    def __init__(self, dataset_file: str | Path) -> None:
+        self.dataset_file = dataset_file
+
+    def __iter__(self) -> Iterator[list[str]]:
+        with open(self.dataset_file, 'r') as file:
+            while (entry := file.readline()):
+                data = json.loads(entry)
+                yield normalize_sentence(data['headline'])
+
+def main() -> int:
+    DATA_DIR = Path(__file__).parent.parent / 'data'
+    GOOGLE_WORD2VEC = DATA_DIR / 'GoogleNews-vectors-negative300.bin'
+    DATASET_JSON = DATA_DIR / 'Sarcasm_Headlines_Dataset.json'
+    OUTPUT_WORD2VEC = DATA_DIR / 'w2v-headline-embeddings-300d.bin'
+
+    print('Initializing model...')
+    headlines = Sentences(DATASET_JSON)
+    model = Word2Vec(vector_size=300, window=5, min_count=1)
+
+    print('Building vocabulary...')
+    model.build_vocab(headlines)
+
+    print('Loading pretrained word2vec embeddings...')
+    model.wv.vectors_lockf = np.ones(len(model.wv))
+    model.wv.intersect_word2vec_format(GOOGLE_WORD2VEC, binary=True)
+
+    print('Learning embeddings...')
+    model.train(headlines,
+                total_examples=model.corpus_count,
+                epochs=model.epochs)
+
+    print(f'Saving embeddings to {OUTPUT_WORD2VEC}...')
+    model.wv.save(str(OUTPUT_WORD2VEC))
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())
+
+
+# sources:
+# https://code.google.com/archive/p/word2vec/
+# https://radimrehurek.com/gensim/models/word2vec.html
+# https://rare-technologies.com/word2vec-tutorial/
+# https://phdstatsphys.wordpress.com/2018/12/27/word2vec-how-to-train-and-update-it/


### PR DESCRIPTION
- add src/word2vec.py, which uses `gensim` to tune the Google News word2vec embeddings to our dataset.
- add data/w2v-headline-embeddings.bin, which contains the learned embedding values.
- add data/get-embeddings.sh to download the huge pre-trained embeddings file without committing it to the source tree.
- fixed an inaccurate type hint in src/data_normalize.py.
- add `gensim` to requirements.txt.