### PR TITLE
bugfix: crash when src/../chkpt doesn't exist

### DIFF
--- a/src/lstm.py
+++ b/src/lstm.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
 
     # Make output directory if it does not exist
     if not os.path.exists(OUT_DIR):
-        os.mkdir(OUT_DIR)
+        os.makedirs(OUT_DIR, exist_ok=True)
 
     # CUDA device
     if args.device is None:


### PR DESCRIPTION
when calling `os.mkdir()` with a path like `../chkpt/chk0`, an exception will be raised because `../chkpt` does not exist.
fixed by replacing `os.mkdir()` with `os.makedirs(..., exist_ok=True)`